### PR TITLE
Roll Amd64 AFDO from 121.0.6120.0_rc-r1-merged to 121.0.6122.0_rc-r1-…

### DIFF
--- a/chrome/android/profiles/newest.txt
+++ b/chrome/android/profiles/newest.txt
@@ -1,1 +1,1 @@
-chromeos-chrome-amd64-121.0.6120.0_rc-r1-merged.afdo.bz2
+chromeos-chrome-amd64-121.0.6122.0_rc-r1-merged.afdo.bz2


### PR DESCRIPTION
…merged

This CL may cause a small binary size increase, roughly proportional to how long it's been since our last AFDO profile roll. For larger increases (around or exceeding 100KB), please file go/crostc-bug.

Please note that, despite rolling to chrome/android, this profile is used for both Linux and Android.

If this roll has caused a breakage, revert this CL and stop the roller using the controls here:
https://autoroll.skia.org/r/afdo-chromium
Please CC c-compiler-chrome@google.com on the revert to ensure that a human is aware of the problem.

To file a bug in Chromium Main: https://bugs.chromium.org/p/chromium/issues/entry

To report a problem with the AutoRoller itself, please file a bug: https://issues.skia.org/issues/new?component=1389291&template=1850622

Documentation for the AutoRoller is here:
https://skia.googlesource.com/buildbot/+doc/main/autoroll/README.md

Tbr: c-compiler-chrome@google.com
Change-Id: I6128a8af0144aa4ad50072f0dc06e6e727f856f2
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5022768
Commit-Queue: chromium-autoroll <chromium-autoroll@skia-public.iam.gserviceaccount.com>
Bot-Commit: chromium-autoroll <chromium-autoroll@skia-public.iam.gserviceaccount.com>
Cr-Commit-Position: refs/heads/main@{#1223371}